### PR TITLE
add bump version script and bump extension toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 The best software agent, powered by industry-leading context engine, is now available in Zed.
 
+## Bumping the Version
+
+```bash
+node bump-version.js           # bump to latest npm version
+node bump-version.js 0.16.0    # bump to a specific version
+```
+
 ## Licensing
 
 The code in this repository is licensed under the MIT License. Brand, product, and service names and marks are trademarks of Augment Code and may not be used without explicit permission.

--- a/bump-version.js
+++ b/bump-version.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_NAME = '@augmentcode/auggie';
+const EXTENSION_TOML_PATH = path.join(__dirname, 'extension.toml');
+
+/**
+ * Fetch the latest version of a package from npm registry
+ */
+function getLatestVersion(packageName) {
+  return new Promise((resolve, reject) => {
+    const url = `https://registry.npmjs.org/${packageName}/latest`;
+
+    https.get(url, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          resolve(json.version);
+        } catch (error) {
+          reject(new Error(`Failed to parse npm registry response: ${error.message}`));
+        }
+      });
+    }).on('error', (error) => {
+      reject(new Error(`Failed to fetch package info: ${error.message}`));
+    });
+  });
+}
+
+/**
+ * Update the extension.toml file with the new version.
+ * Sets both the extension version and archive URLs to the same version.
+ */
+function updateExtensionToml(newVersion) {
+  try {
+    let content = fs.readFileSync(EXTENSION_TOML_PATH, 'utf8');
+
+    // Read current versions for logging
+    const currentExtVersionMatch = content.match(/^version = "([\d.]+)"$/m);
+    const currentExtVersion = currentExtVersionMatch ? currentExtVersionMatch[1] : 'unknown';
+    const currentPkgMatch = content.match(/auggie-([\d.]+)\.tgz/);
+    const currentPkgVersion = currentPkgMatch ? currentPkgMatch[1] : 'unknown';
+
+    // Update the extension version to match the package version
+    content = content.replace(
+      /^version = "[\d.]+"$/m,
+      `version = "${newVersion}"`
+    );
+    console.log(`Updated extension version: ${currentExtVersion} -> ${newVersion}`);
+
+    // Update the archive URLs for all targets
+    const oldUrlPattern = /archive = "https:\/\/registry\.npmjs\.org\/@augmentcode\/auggie\/-\/auggie-[\d.]+\.tgz"/g;
+    const newUrl = `archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-${newVersion}.tgz"`;
+    content = content.replace(oldUrlPattern, newUrl);
+    console.log(`Updated auggie package version: ${currentPkgVersion} -> ${newVersion}`);
+
+    fs.writeFileSync(EXTENSION_TOML_PATH, content, 'utf8');
+    return true;
+  } catch (error) {
+    console.error(`Failed to update extension.toml: ${error.message}`);
+    return false;
+  }
+}
+
+function printUsage() {
+  console.log('Usage: node bump-version.js [version]');
+  console.log('');
+  console.log('  version   Explicit version to bump to (e.g. 0.16.0)');
+  console.log('            If omitted, fetches the latest version from npm.');
+  console.log('');
+  console.log('Examples:');
+  console.log('  node bump-version.js           # bump to latest npm version');
+  console.log('  node bump-version.js 0.16.0    # bump to specific version');
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const explicitVersion = args[0];
+
+  try {
+    let targetVersion;
+
+    if (explicitVersion) {
+      if (!/^\d+\.\d+\.\d+$/.test(explicitVersion)) {
+        console.error(`Error: Invalid version format "${explicitVersion}". Expected semver (e.g. 0.16.0)`);
+        process.exit(1);
+      }
+      targetVersion = explicitVersion;
+      console.log(`Using explicit version: ${targetVersion}`);
+    } else {
+      console.log(`Fetching latest version of ${PACKAGE_NAME}...`);
+      targetVersion = await getLatestVersion(PACKAGE_NAME);
+      console.log(`Latest version: ${targetVersion}`);
+    }
+
+    // Check current version in extension.toml
+    const content = fs.readFileSync(EXTENSION_TOML_PATH, 'utf8');
+    const currentMatch = content.match(/auggie-([\d.]+)\.tgz/);
+    const currentVersion = currentMatch ? currentMatch[1] : 'unknown';
+
+    if (currentVersion === targetVersion) {
+      console.log(`Already at version ${targetVersion}. No update needed.`);
+      return;
+    }
+
+    console.log(`Bumping from ${currentVersion} to ${targetVersion}...`);
+
+    const success = updateExtensionToml(targetVersion);
+
+    if (success) {
+      console.log('✓ Version bump completed successfully!');
+    } else {
+      console.error('✗ Version bump failed');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "auggie"
 name = "Auggie CLI"
-version = "0.13.0"
+version = "0.16.0"
 schema_version = 1
 authors = ["Augment Code <support@augmentcode.com>"]
 description = "Augment Code's powerful software agent, backed by industry-leading context engine"
@@ -11,31 +11,31 @@ name = "Auggie CLI"
 icon = "auggie.svg"
 
 [agent_servers.auggie.targets.darwin-aarch64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.13.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.darwin-x86_64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.13.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.linux-aarch64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.13.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.linux-x86_64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.13.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.windows-x86_64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.13.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }


### PR DESCRIPTION
## Summary

Adds a `bump-version.js` script to automate version bumps and bumps the extension to `0.16.0`.

## Changes

- **`bump-version.js`** — Updated to:
  - Set the extension version equal to the npm package version (matching the pattern from #11)
  - Accept an explicit version via CLI argument (e.g. `node bump-version.js 0.16.0`)
  - Fall back to fetching the latest version from npm when no argument is provided
  - Validate semver format and include `--help` flag
- **`extension.toml`** — Bumped version and all archive URLs from `0.13.0` → `0.16.0`
- **`README.md`** — Added usage instructions for the bump script

## Usage

```bash
node bump-version.js           # bump to latest npm version
node bump-version.js 0.16.0    # bump to a specific version
```

## Testing
Tested that this dev extension works and loads the new session info

<img width="1142" height="111" alt="image" src="https://github.com/user-attachments/assets/7c056323-8705-4418-9fc6-b60abcaff078" />
<img width="541" height="275" alt="image" src="https://github.com/user-attachments/assets/39a12a40-22bc-4cd1-a405-57a9ec81c54f" />
