### PR TITLE
Restore Zed ACP model selection

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "auggie"
 name = "Auggie CLI"
-version = "0.16.0"
+version = "0.33.0"
 schema_version = 1
 authors = ["Augment Code <support@augmentcode.com>"]
 description = "Augment Code's powerful software agent, backed by industry-leading context engine"
@@ -11,31 +11,31 @@ name = "Auggie CLI"
 icon = "auggie.svg"
 
 [agent_servers.auggie.targets.darwin-aarch64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.33.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.darwin-x86_64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.33.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.linux-aarch64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.33.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.linux-x86_64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.33.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }
 
 [agent_servers.auggie.targets.windows-x86_64]
-archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.16.0.tgz"
+archive = "https://registry.npmjs.org/@augmentcode/auggie/-/auggie-0.33.0.tgz"
 cmd = "node"
 args = ["./package/augment.mjs", "--acp"]
 env = { AUGMENT_DISABLE_AUTO_UPDATE = "1" }


### PR DESCRIPTION
Closes https://linear.app/augmentcode/issue/CSS-1158/restore-model-selection-in-auggie-acp-mode-zed-editor

**Solution**
Update the bundled Auggie CLI from 0.16.0 to 0.33.0 so Zed receives current ACP model/config-option support.

**Testing**
Validated the manifest, all five archive URLs, and the packaged CLI startup/version.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KYR7RFRG22JB8NYM8F98VXQM&panel=chat)