### PR TITLE
Document model selection for Auggie ACP in Zed (CSS-1158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 The best software agent, powered by industry-leading context engine, is now available in Zed.
 
+## Choosing a Model
+
+Zed no longer renders a model dropdown for external ACP agents. Zed removed the unstable
+ACP model selector in [zed#58308](https://github.com/zed-industries/zed/pull/58308)
+(first shipped in Zed v1.6.0), replacing it with ACP session config options. Auggie still
+advertises `models` in its `session/new` response, so the picker disappears until Auggie
+exposes the model as a session config option. Tracked in CSS-1158.
+
+Until then, set the model outside the picker:
+
+- Set `"model": "<model-id>"` in `~/.augment/settings.json`. This applies to every Auggie
+  session, including the one Zed launches through this extension.
+- Or define your own agent server in Zed's `settings.json` and pass `-m <model-id>`:
+
+  ```json
+  {
+    "agent_servers": {
+      "Auggie CLI (custom)": {
+        "command": "auggie",
+        "args": ["--acp", "-m", "<model-id>"]
+      }
+    }
+  }
+  ```
+
+  Zed only honors `env` overrides for extension-provided agent servers, so `args` must be
+  set on a custom entry.
+
+Run `auggie model list` to see the model IDs available to your account.
+
 ## Bumping the Version
 
 ```bash


### PR DESCRIPTION
## Problem

[CSS-1158](https://linear.app/augmentcode/issue/CSS-1158/restore-model-selection-in-auggie-acp-mode-zed-editor) — the model dropdown disappeared for Auggie over ACP in Zed.

Root cause is Zed-side, not Auggie-side: Zed removed the unstable ACP model selector in [zed#58308](https://github.com/zed-industries/zed/pull/58308) (merged 2026-06-02, first tag `v1.6.0-pre`), replacing it with ACP session config options. On Zed `main`, `impl AgentConnection for AcpConnection` no longer implements `model_selector()`, so no external ACP agent gets a model dropdown. The `0.29.0` correlation is timing: Auggie 0.29.0 published 2026-06-05, days after that Zed change.

Auggie still emits `models` (and `modes`) in `session/new` but emits `configOptions: null`, so there is nothing for current Zed to render.

## Solution

This repo only ships a declarative `extension.toml`; it cannot change what Auggie advertises over ACP, and Zed only honors `env` overrides for extension-provided agent servers. So the actual fix — Auggie exposing the model as an ACP session config option — belongs in the Auggie CLI, and CSS-1158 should carry that work.

This PR documents the root cause and the two working ways to pick a model today (`model` in `~/.augment/settings.json`, or a custom Zed agent server entry passing `-m`).

## Testing

Verified by driving `session/new` over stdio against Auggie 0.16.0 / 0.28.0 / 0.29.0 / 0.36.0 / 0.37.0-prerelease.3:

- all versions return identical `initialize` results (`protocolVersion: 1`) and a populated `models.availableModels` (40 models) — no Auggie regression at 0.29.0;
- all versions return `configOptions: null`;
- `auggie --acp -m claude-sonnet-4-6` yields `currentModelId: "claude-sonnet-4-6"`, confirming the documented `-m` workaround.

No automated test added: the change is documentation-only and the ACP handshake requires an authenticated account.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01M0YQ7GX931G00NGZY8MQRWCG&panel=chat)